### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "html"
+run = ""

--- a/README.md
+++ b/README.md
@@ -3,5 +3,7 @@ C++ Game Gravity Physics similar to the arcade game Joust
 
 Project page https://amiedd.github.io/Game-Gravity-Physics-Joust/
 
+[![Run on Repl.it](https://repl.it/badge/github/AmieDD/Game-Gravity-Physics-Joust)](https://repl.it/github/AmieDD/Game-Gravity-Physics-Joust)
+
 <p data-height="265" data-theme-id="0" data-slug-hash="WYgdOo" data-default-tab="js,result" data-user="amiedd" data-pen-title="C++ Game Gravity Physics" class="codepen">See the Pen <a href="https://codepen.io/amiedd/pen/WYgdOo/">C++ Game Gravity Physics</a> by Amie Dansby (<a href="https://codepen.io/amiedd">@amiedd</a>) on <a href="https://codepen.io">CodePen</a>.</p>
 <script async src="https://static.codepen.io/assets/embed/ei.js"></script>


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@AmieDD/Game-Gravity-Physics-Joust).